### PR TITLE
Removing Xranklin dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"
 NodeJS = "2bd173c7-0d6d-553b-b6af-13a54713934c"
-Xranklin = "558449b0-171e-4e1f-900f-d076a5ddf486"
 
 [compat]
 Franklin = "0.10.56"

--- a/index.md
+++ b/index.md
@@ -1,2 +1,4 @@
+@def title = "News"
+
 {{news}}
 

--- a/news/index.md
+++ b/news/index.md
@@ -1,3 +1,5 @@
+@def title = "News"
+
 {{news}}
 
 


### PR DESCRIPTION
Removing Xranklin dependency and adding two missing variables to avoid warnings. The issue related to variables arbitrarily set to 'nothing' persists (see https://github.com/tlienart/Franklin.jl/issues/937). You must run 'serve' twice for it to work. Is this a bug in Franklin?