### PR TITLE
Separate entries by year and make DOI+arXiv human-readable

### DIFF
--- a/resources/index.md
+++ b/resources/index.md
@@ -11,6 +11,7 @@ and how to get in touch with the community.
 
 Workshops about performance engineering, GPU programming and general use of Julia in HPC:
 
+### 2022
 * [Julia for HPC](https://sc22.supercomputing.org/presentation/?id=bof136&sess=sess309)
   Birds of a Feather session at SuperComputing22 (SC22)
   ([material](https://github.com/JuliaParallel/julia-hpc-bof-sc22)), by William F. Godoy,
@@ -25,6 +26,8 @@ Workshops about performance engineering, GPU programming and general use of Juli
   by William F Godoy, Michael Schlottke-Lakemper, Carsten Bauer, Samuel Omlin, Simon Byrne, Tim Besard,
   Julian Samaroo, Albert Reuther, Johannes Blaschke, Ludovic
   Räss. July 26th, 2022.
+
+### 2021
 * [GPU Programming with Julia @ CSCS/ETH Zurich](https://github.com/omlins/julia-gpu-course)
   ([video recording](https://youtu.be/LmM2QmYw_NM)), by Tim Besard, Samuel Omlin. November
   2nd-5th, 2021.
@@ -32,6 +35,8 @@ Workshops about performance engineering, GPU programming and general use of Juli
   by Carsten Bauer. March 15th-17th, 2021.
 * [Julia Workshop @ HPC.NRW](https://github.com/carstenbauer/JuliaNRW21),
   by Carsten Bauer. March 2nd-4th, 2021. ([second edition](https://github.com/carstenbauer/JuliaNRWSS21), June 22th-24th)
+
+### 2020 and older
 * [Julia Workshop @ University of Oulu](https://github.com/carstenbauer/JuliaOulu20),
   by Carsten Bauer. February 11th-13th, 2020.
 * [Julia performance
@@ -54,36 +59,47 @@ Workshops about performance engineering, GPU programming and general use of Juli
 
 Some of the papers using Julia in HPC, including the JuliaParallel software stack:
 
+### 2022
 * V. Churavy, W. F Godoy, C. Bauer, H. Ranocha, M. Schlottke-Lakemper, L. Räss, J. Blaschke,
-  M. Giordano, E. Schnetter, S. Omlin, J. S. Vetter, and A. Edelman, _[Bridging HPC
-  Communities through the Julia Programming Language](https://arxiv.org/abs/2211.02740)_,
-  2022, arXiv:2211.02740.
-* M. Giordano, M. Klöwer and V. Churavy, _[Productivity meets Performance: Julia on
-  A64FX](https://doi.org/10.1109/CLUSTER51413.2022.00072)_, 2022 IEEE International Conference
+  M. Giordano, E. Schnetter, S. Omlin, J. S. Vetter, and A. Edelman, **Bridging HPC
+  Communities through the Julia Programming Language**,
+  2022, [arXiv:2211.02740](https://arxiv.org/abs/2211.02740).
+* M. Giordano, M. Klöwer and V. Churavy, **Productivity meets Performance: Julia on
+  A64FX**, 2022 IEEE International Conference
   on Cluster Computing (CLUSTER), 2022, pp. 549-555,
-  (pre-print: [arXiv:2207.12762](https://arxiv.org/abs/2207.12762)).
-* H. Shang et al., (2022). _[Large-Scale Simulation of Quantum Computational Chemistry on a
-  New Sunway Supercomputer](https://arxiv.org/abs/2207.03711)_. arXiv:2207.03711.
-* W. C. Lin and S. McIntosh-Smith, _[Comparing Julia to Performance Portable Parallel
-  Programming Models for HPC](https://doi.org/10.1109/PMBS54543.2021.00016)_, 2021
+  [doi:10.1109/CLUSTER51413.2022.00072](https://doi.org/10.1109/CLUSTER51413.2022.00072),
+  [arXiv:2207.12762](https://arxiv.org/abs/2207.12762).
+
+### 2021
+* H. Shang et al., (2022). **Large-Scale Simulation of Quantum Computational Chemistry on a
+  New Sunway Supercomputer**. [arXiv:2207.03711](https://arxiv.org/abs/2207.03711).
+* W. C. Lin and S. McIntosh-Smith, **Comparing Julia to Performance Portable Parallel
+  Programming Models for HPC**, 2021
   International Workshop on Performance Modeling, Benchmarking and Simulation of High
-  Performance Computer Systems (PMBS), 2021, pp. 94-105.
-* A. Rizvi, K. C. Hale, (2021). _[A Look at Communication-Intensive Performance in
-  Julia](https://arxiv.org/abs/2109.14072)_. arXiv:2109.14072.
-* S. Byrne, L. C. Wilcox and V. Churavy, (2021). _[MPI.jl: Julia bindings for the Message
-  Passing Interface](https://doi.org/10.21105/jcon.00068)_. JuliaCon Proceedings, 1(1), 68.
-* C. Bauer, Y. Schattner, S. Trebst, and E Berg, _[Hierarchy of energy scales in an O(3)
+  Performance Computer Systems (PMBS), 2021, pp. 94-105,
+  [doi:10.1109/PMBS54543.2021.00016](https://doi.org/10.1109/PMBS54543.2021.00016).
+* A. Rizvi, K. C. Hale, (2021). **A Look at Communication-Intensive Performance in
+  Julia**. [arXiv:2109.14072](https://arxiv.org/abs/2109.14072).
+* S. Byrne, L. C. Wilcox and V. Churavy, (2021). **MPI.jl: Julia bindings for the Message
+  Passing Interface**. JuliaCon Proceedings, 1(1), 68,
+  [doi:10.21105/jcon.00068](https://doi.org/10.21105/jcon.00068).
+
+### 2020 and older
+* C. Bauer, Y. Schattner, S. Trebst, and E Berg, **Hierarchy of energy scales in an O(3)
   symmetric antiferromagnetic quantum critical metal: a Monte Carlo
-  study](https://doi.org/10.1103/PhysRevResearch.2.023008)_, 2020, Phys. Rev. Research 2,
-  023008.
-* S. Hunold and S. Steiner, _[Benchmarking Julia’s Communication Performance: Is Julia HPC
-  ready or Full HPC?](https://doi.org/10.1109/PMBS51919.2020.00008)_, 2020 IEEE/ACM
+  study**, 2020, Phys. Rev. Research 2,
+  023008,
+  [doi:10.1103/PhysRevResearch.2.023008](https://doi.org/10.1103/PhysRevResearch.2.023008).
+* S. Hunold and S. Steiner, **Benchmarking Julia’s Communication Performance: Is Julia HPC
+  ready or Full HPC?**, 2020 IEEE/ACM
   Performance Modeling, Benchmarking and Simulation of High Performance Computer Systems
-  (PMBS), 2020, pp. 20-25.
-* J. Regier et al., _[Cataloging the visible universe through Bayesian inference in Julia at
-  petascale](https://doi.org/10.1016/j.jpdc.2018.12.008)_, Journal of Parallel and
-  Distributed Computing, Volume 127, 2019, Pages 89-104, (preprint:
-  [arXiv:1801.10277](https://arxiv.org/abs/1801.10277)).
+  (PMBS), 2020, pp. 20-25,
+  [doi:10.1109/PMBS51919.2020.00008](https://doi.org/10.1109/PMBS51919.2020.00008).
+* J. Regier et al., **Cataloging the visible universe through Bayesian inference in Julia at
+  petascale**, Journal of Parallel and
+  Distributed Computing, Volume 127, 2019, Pages 89-104,
+  [doi:10.1016/j.jpdc.2018.12.008](https://doi.org/10.1016/j.jpdc.2018.12.008),
+  [arXiv:1801.10277](https://arxiv.org/abs/1801.10277).
   <!-- For some reason Xranklin seems to duplicate the character after the last `)` if it's
 	   only one, so we put something else to work around this bug. -->
 

--- a/resources/index.md
+++ b/resources/index.md
@@ -6,6 +6,10 @@ title = "Resources"
 
 All you wanted to know about Julia in High-Performance Computing (HPC): workshops, papers,
 and how to get in touch with the community.
+If you find something to be missing, please create a PR to the
+[website repo](https://github.com/JuliaParallel/juliaparallel.github.io)
+with the relevant information to help ensure that this overview is as
+comprehensive as possible.
 
 ## Workshops
 


### PR DESCRIPTION
I propose two changes and a small addition:

1. **Separate entries by year:** This makes it easier to find the most recent ones and gives immediate visual feedback on the vibrancy and timeliness of the data.
2. **Separately encode DOI and arXiv:** I am not a fan of making the title a clickable link. Why? Because I don't like to click on stuff where I don't know where it will take me. If the links are explicitly given as DOI and arXiv links, however, I am too lazy/gullible to check and just assume that they will take me to the expected pages. As noted by @ranocha in the chat, I also think we should include arXiv whenever possible to be more inclusive towards people without institutional access to traditional publications.
3. **Add a statement on contributions:** If possible, people should be encouraged to add missing information. I found that for this to happen, the entry barrier should be as low as possible, thus I suggest to include the link to the repo here as well (even though it can be found elsewhere on the website too).