### PR TITLE
Fix commas showing in tab title

### DIFF
--- a/_layout/head.html
+++ b/_layout/head.html
@@ -13,7 +13,7 @@
   {{if hascode}} {{insert head_highlight.html }}   {{end}}
   <script defer data-domain="juliaparallel.org" src="https://plausible.io/js/plausible.js"></script>
   {{insert style.html}}
-  {{isdef title}} <title>{{fill title}}</title>  {{end}}
+  {{isdef title}} <title>{{title}}</title>  {{end}}
   <!-- end custom head snippets -->
   
 </head>


### PR DESCRIPTION
A user showed that the tab title showed a `"..."`, this is a bug in Xranklin it seems  due to a difference in `{{fill title}}` vs `{{title}}` (which shouldn't be there). 

https://github.com/tlienart/Xranklin.jl/issues/194

in the meantime this commit should remove those spurious `"`.

![image](https://github.com/JuliaParallel/juliaparallel.github.io/assets/10897531/077021cb-8121-4b11-8dd8-6f5ad9a13918)

**Edit**: fwiw the issue has been fixed but as I think you're using a fixed version of Xranklin, you'll need to update that. So either you just bring this PR in, or you update Xranklin and can either merge or close this PR.
